### PR TITLE
(maint) add a logging config to jetty quieter

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -38,6 +38,8 @@
 
   :lein-release {:scm :git, :deploy-via :lein-deploy}
 
+  :test-paths ["test" "test-resources"]
+
   :profiles {:dev {:dependencies [[puppetlabs/cthun "0.2.0-SNAPSHOT" :exclusions [joda-time com.taoensso/encore clj-time cheshire com.taoensso/nippy]]
                                   [puppetlabs/trapperkeeper "1.1.1" :classifier "test" :scope "test"]
                                   [puppetlabs/kitchensink ~ks-version :classifier "test" :scope "test"]]}})

--- a/test-resources/logback.xml
+++ b/test-resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration scan="true">
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d %-5p [%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="puppetlabs" level="error"/>
+    <logger name="log4j.logger.org.eclipse.jetty.server" level="warn"/>
+    <logger name="log4j.logger.org.eclipse.jetty.util.log" level="warn"/>
+
+    <root level="error">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
Here we add a logback.xml, and add test-resources to the :test-paths
key for the leiningen project, so that the logback.xml is loaded.
