### PR TITLE
Update dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,11 +20,19 @@
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/tools.logging "0.3.1"]
                  [prismatic/schema "0.4.3"]
+
+                 ;; Transitive dependency for ssl-utils and cthun-message
+                 [clj-time "0.9.0"]
+
                  [puppetlabs/ssl-utils "0.8.1"]
-                 [puppetlabs/cthun-message "0.2.0" :exclusions [clj-time]]
-                 ;; bring in a newer version of jetty9 than gniazdo depends on
+                 [puppetlabs/cthun-message "0.2.0"]
+
+                 ;; Transitive dependencies on jetty for gniazdo
+                 ;; to use the stable jetty release (gniazdo specifies 9.3.0M1)
                  [org.eclipse.jetty.websocket/websocket-client ~jetty-version]
+
                  [stylefruits/gniazdo "0.4.0" :exclusions [org.eclipse.jetty.websocket/websocket-client]]
+
                  ;; try+/throw+
                  [slingshot "0.12.2"]]
 
@@ -40,6 +48,6 @@
 
   :test-paths ["test" "test-resources"]
 
-  :profiles {:dev {:dependencies [[puppetlabs/cthun "0.2.0-SNAPSHOT" :exclusions [joda-time com.taoensso/encore clj-time cheshire com.taoensso/nippy]]
+  :profiles {:dev {:dependencies [[puppetlabs/cthun "0.2.0-SNAPSHOT"]
                                   [puppetlabs/trapperkeeper "1.1.1" :classifier "test" :scope "test"]
                                   [puppetlabs/kitchensink ~ks-version :classifier "test" :scope "test"]]}})


### PR DESCRIPTION
Bump cthun-message dep to 0.2.0

Rework the way we resolve pedantic dependencies to the new standard.
