### PR TITLE
CTH-331 rename uri schema from cth to pcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ the following to your project.clj
 (client/send! conn
               (-> (message/make-message)
                   (message/set-expiry 3 :seconds)
-                  (assoc :targets ["cth://*/demo-client"]
+                  (assoc :targets ["pcp://*/demo-client"]
                          :message_type "example/any_schema")))
 
 (client/send! conn
               (-> (message/make-message)
                   (message/set-expiry 3 :seconds)
-                  (assoc :targets ["cth://*/demo-client"]
+                  (assoc :targets ["pcp://*/demo-client"]
                          :message_type "example/cnc_request")
                   (message/set-json-data {:action "demo"})))
 

--- a/examples/README.clj
+++ b/examples/README.clj
@@ -38,7 +38,7 @@
 (client/send! conn
               (-> (message/make-message)
                   (message/set-expiry 3 :seconds)
-                  (assoc :targets ["cth://*/demo-client"]
+                  (assoc :targets ["pcp://*/demo-client"]
                          :message_type "example/any_schema")))
 
 (log/info "### sending example/cnc_request")
@@ -46,7 +46,7 @@
 (client/send! conn
               (-> (message/make-message)
                   (message/set-expiry 3 :seconds)
-                  (assoc :targets ["cth://*/demo-client"]
+                  (assoc :targets ["pcp://*/demo-client"]
                          :message_type "example/cnc_request")
                   (message/set-json-data {:action "demo"})))
 

--- a/examples/controller.clj
+++ b/examples/controller.clj
@@ -58,16 +58,16 @@
          cl
          (-> (message/make-message)
              (message/set-expiry 4 :seconds)
-             (assoc :targets ["cth:///server"]
+             (assoc :targets ["pcp:///server"]
                     :message_type "http://puppetlabs.com/inventory_request")
-             (message/set-json-data {:query ["cth://*/agent"]})))
+             (message/set-json-data {:query ["pcp://*/agent"]})))
 
        (log/info "### sending agent request")
        (client/send!
          cl
          (-> (message/make-message)
              (message/set-expiry 4 :seconds)
-             (assoc :targets ["cth://*/agent"]
+             (assoc :targets ["pcp://*/agent"]
                     :message_type "example/request")
              (message/set-json-data {:action "demo"})))
        (log/info "### waiting for 60 s")

--- a/project.clj
+++ b/project.clj
@@ -22,7 +22,7 @@
                  [clj-time "0.9.0"]
 
                  [puppetlabs/ssl-utils "0.8.1"]
-                 [puppetlabs/pcp-common "0.4.0"]
+                 [puppetlabs/pcp-common "0.4.1"]
 
                  ;; Transitive dependencies on jetty for stylefuits/gniazdo
                  ;; to use a stable jetty release (gniazdo specifies 9.3.0M1)
@@ -45,6 +45,6 @@
 
   :test-paths ["test" "test-resources"]
 
-  :profiles {:dev {:dependencies [[puppetlabs/pcp-broker "0.2.0"]
+  :profiles {:dev {:dependencies [[puppetlabs/pcp-broker "0.2.1"]
                                   [puppetlabs/trapperkeeper "1.1.1" :classifier "test" :scope "test"]
                                   [puppetlabs/kitchensink "1.1.0" :classifier "test" :scope "test"]]}})

--- a/src/puppetlabs/pcp/client.clj
+++ b/src/puppetlabs/pcp/client.clj
@@ -95,7 +95,7 @@
 (s/defn ^:always-validate ^:private session-association-message :- Message
   [client :- Client]
   (-> (message/make-message :message_type "http://puppetlabs.com/associate_request"
-                            :targets ["cth:///server"])
+                            :targets ["pcp:///server"])
       (message/set-expiry 3 :seconds)))
 
 (defn fallback-handler
@@ -124,7 +124,7 @@
   [certificate type]
   (let [x509     (ssl-utils/pem->cert certificate)
         cn       (ssl-utils/get-cn-from-x509-certificate x509)
-        identity (format "cth://%s/%s" cn type)]
+        identity (format "pcp://%s/%s" cn type)]
     identity))
 
 (s/defn ^:always-validate ^:private heartbeat

--- a/test/puppetlabs/pcp/client_test.clj
+++ b/test/puppetlabs/pcp/client_test.clj
@@ -14,7 +14,7 @@
    :cert ""
    :private-key ""
    :type ""
-   :identity "cth://the_identity/the_type"
+   :identity "pcp://the_identity/the_type"
    :conn ""
    :state (atom :connecting)
    :websocket ""
@@ -55,5 +55,5 @@
 (def make-identity #'puppetlabs.pcp.client/make-identity)
 
 (deftest make-identity-test
-  (is (= "cth://broker.example.com/test"
+  (is (= "pcp://broker.example.com/test"
          (make-identity "test-resources/ssl/certs/broker.example.com.pem" "test"))))

--- a/test/puppetlabs/pcp/messaging_test.clj
+++ b/test/puppetlabs/pcp/messaging_test.clj
@@ -56,7 +56,7 @@
             message       (-> (message/make-message)
                               (message/set-expiry 3 :seconds)
                               (message/set-data (byte-array (.getBytes expected-data "UTF-8")))
-                              (assoc :targets      ["cth://client02.example.com/demo-client"]
+                              (assoc :targets      ["pcp://client02.example.com/demo-client"]
                                      :message_type "example/any_schema"))
             received      (promise)
             sender        (connect-controller "client01" (constantly true))
@@ -71,4 +71,4 @@
         (is (= (:message_type message) (:message_type @received)))
         (is (= (:expires message) (:expires @received)))
         (is (= (:targets message) (:targets @received)))
-        (is (= "cth://client01.example.com/demo-client" (:sender @received)))))))
+        (is (= "pcp://client01.example.com/demo-client" (:sender @received)))))))


### PR DESCRIPTION
Here we bring in updated versions of puppetlabs/pcp-common and
puppetlabs/pcp-broker and update the schema used in PCP Uri's to pcp.
