### PR TITLE
(maint) change default port to 8142

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ the following to your project.clj
 
 ;; connecting with handlers
 (def conn (client/connect
-           {:server "wss://localhost:8090/pcp/"
+           {:server "wss://localhost:8142/pcp/"
             :cert "test-resources/ssl/certs/0001_controller.pem"
             :private-key "test-resources/ssl/private_keys/0001_controller.pem"
             :cacert "test-resources/ssl/certs/ca.pem"

--- a/examples/README.clj
+++ b/examples/README.clj
@@ -23,7 +23,7 @@
 
 ;; connecting with handlers
 (def conn (client/connect
-            {:server      "wss://localhost:8090/pcp/"
+            {:server      "wss://localhost:8142/pcp/"
              :cert        "test-resources/ssl/certs/client03.example.com.pem"
              :private-key "test-resources/ssl/private_keys/client03.example.com.pem"
              :cacert      "test-resources/ssl/certs/ca.pem"

--- a/examples/agent.clj
+++ b/examples/agent.clj
@@ -54,7 +54,7 @@
       (log/info "Default handler got message" msg))
 
 (def agent-params
-  {:server      "wss://localhost:8090/pcp/"
+  {:server      "wss://localhost:8142/pcp/"
    :cert        "test-resources/ssl/certs/client02.example.com.pem"
    :private-key "test-resources/ssl/private_keys/client02.example.com.pem"
    :cacert      "test-resources/ssl/certs/ca.pem"

--- a/examples/controller.clj
+++ b/examples/controller.clj
@@ -34,7 +34,7 @@
   (log/warn "&&& Default handler got message" msg))
 
 (def controller-params
-  {:server      "wss://localhost:8090/pcp/"
+  {:server      "wss://localhost:8142/pcp/"
    :cert        "test-resources/ssl/certs/client01.example.com.pem"
    :private-key "test-resources/ssl/private_keys/client01.example.com.pem"
    :cacert      "test-resources/ssl/certs/ca.pem"

--- a/test/puppetlabs/pcp/messaging_test.clj
+++ b/test/puppetlabs/pcp/messaging_test.clj
@@ -14,7 +14,8 @@
 (def broker-config
   "A broker with ssl and own spool"
   {:webserver {:ssl-host     "127.0.0.1"
-               :ssl-port     8081
+               ;; Default port is 8142.  Use 8143 here so we don't clash.
+               :ssl-port     8143
                :client-auth  "want"
                :ssl-key      "./test-resources/ssl/private_keys/broker.example.com.pem"
                :ssl-cert     "./test-resources/ssl/certs/broker.example.com.pem"
@@ -38,7 +39,7 @@
 (defn connect-controller
   [controller-id handler-function]
   (client/connect
-   {:server      "wss://localhost:8081/pcp/"
+   {:server      "wss://localhost:8143/pcp/"
     :cert        (str "test-resources/ssl/certs/" controller-id ".example.com.pem")
     :private-key (str "test-resources/ssl/private_keys/" controller-id ".example.com.pem")
     :cacert      "test-resources/ssl/certs/ca.pem"


### PR DESCRIPTION
Update the examples and README to use 8142 as the new production port.  Test
brokers on 8143.