### PR TITLE
(maint) revisit defaults for test logging

### DIFF
--- a/test-resources/logback.xml
+++ b/test-resources/logback.xml
@@ -5,11 +5,12 @@
         </encoder>
     </appender>
 
-    <root level="info">
+    <root level="warn">
         <appender-ref ref="STDOUT" />
     </root>
 
     <logger name="log4j.logger.org.eclipse.jetty.server" level="warn"/>
     <logger name="log4j.logger.org.eclipse.jetty.util.log" level="warn"/>
-    <logger name="puppetlabs" level="debug"/>
+    <logger name="puppetlabs.pcp.client" level="debug"/>
+    <logger name="puppetlabs.pcp.broker" level="info"/>
 </configuration>


### PR DESCRIPTION
We'd made the logging too chatty by default for running tests.
Default loglevel is now warn, with info for the broker, and debug
for the code under test.