### PR TITLE
PCP-43 enable use of with-open

### DIFF
--- a/examples/agent.clj
+++ b/examples/agent.clj
@@ -70,7 +70,7 @@
   "Connect to the broker and wait for requests"
   []
   (log/info "### connecting")
-  (let [agent (client/connect agent-params agent-handlers)]
+  (with-open [agent (client/connect agent-params agent-handlers)]
        (log/info "### connected")
        (while (contains? #{:closing :closed} (client/state agent))
               (Thread/sleep 1000))

--- a/examples/controller.clj
+++ b/examples/controller.clj
@@ -52,7 +52,7 @@
   "Connect to the broker and send a request to the agent"
   []
   (log/info "### connecting")
-  (let [cl (client/connect controller-params controller-handlers)]
+  (with-open [cl (client/connect controller-params controller-handlers)]
        (log/info "### sending inventory request")
        (client/send!
          cl
@@ -71,7 +71,6 @@
                     :message_type "example/request")
              (message/set-json-data {:action "demo"})))
        (log/info "### waiting for 60 s")
-       (Thread/sleep 60000)
-       (client/close cl)))
+       (Thread/sleep 60000)))
 
 (time (start))


### PR DESCRIPTION
Here we refactor a little to add a protocol that a pcp client will
implement (ClientInterface) and make Client be implemented as a
record type that implements this protocol.

This allows us to make use of with-open to ensure the close function is called
when we're done with a client, and more cleanly delinates the border between
client API and client implementation.

Also we've reordered some of the functions to match what seemed to be a more
logical narrative for the order of the ClientInterface, and ensured that all
functions are now schematised.