### PR TITLE
(maint) prepare to be an open project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,62 @@
+## 0.1.0
+
+This is a feature and maintenance release
+
+* Added standard cljfmt alias
+* Added ASL 2.0 LICENSE
+* Reworked ports in the examples to use the standard PCP port of 8142
+* [PCP-24](https://tickets.puppetlabs.com/browse/PCP-24) Added reconnection
+  logic.
+* Updated pcp-broker dependency to 0.2.2 to get benefit of CTH-251 fixes.
+* [PCP-43](https://tickets.puppetlabs.com/browse/PCP-43) Refactored flow of
+  client so it can be used with `with-open`.
+
+## 0.0.7
+
+This is a maintenance release
+
+* [CTH-331](https://tickets.puppetlabs.com/browse/CTH-331) Uri scheme updated
+  from `cth` to `pcp`
+
+## 0.0.6
+
+This is a feature and maintenance release
+
+* [CTH-305](https://tickets.puppetlabs.com/browse/CTH-305) Websocket pings are
+  now sent at a regular interval to heartbeat the connection.
+* [CTH-311](https://tickets.puppetlabs.com/browse/CTH-311) distribution renamed
+  from puppetlabs/cthun-client to puppetlabs/pcp-client
+
+## 0.0.5
+
+This is a feature release
+
+* [CTH-337](https://tickets.puppetlabs.com/browse/CTH-337) Identity is now
+  derived from client common-name and client type.
+
+## 0.0.4
+
+This is a maintenance release
+
+* Updated puppetlabs/cthun-message depenency from 0.1.0 to 0.2.0
+* Changed to a behaviour of fixing version incompatibilities via explicit
+  version hoiting, rather than excludes proliferation.
+
+## 0.0.3
+
+This is a maintenance release
+
+* [CTH-215](https://tickets.puppetlabs.com/browse/CTH-215) Added test that
+  starts a broker to test real message sending.
+* Fix namespace declarations caught by eastwood
+
+## 0.0.2
+
+This is a feature and maintenance release
+
+* Update puppetlabs/cthun-message dependency from 0.0.1 to 0.1.0
+* [CTH-212](https://tickets.puppetlabs.com/browse/CTH-212) Renames and rework for updates to protocol specificatons.
+
+## 0.0.1
+
+* Initial internal release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# How to contribute
+
+Third-party patches are essential for keeping puppet open-source projects
+great. We want to keep it as easy as possible to contribute changes that
+allow you to get the most out of our projects. There are a few guidelines
+that we need contributors to follow so that we can have a chance of keeping on
+top of things.  For more info, see our canonical guide to contributing:
+
+[https://github.com/puppetlabs/puppet/blob/master/CONTRIBUTING.md](https://github.com/puppetlabs/puppet/blob/master/CONTRIBUTING.md)

--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,0 @@
-# 0.0.2
-
-* Reworked for semantic changes in CTH-212
-
-# 0.0.1
-
-* Initial internal release

--- a/README.md
+++ b/README.md
@@ -68,3 +68,8 @@ the following to your project.clj
 
 (client/close conn)
 ```
+
+# Support
+
+We use the [Puppet Communications Protocol project on JIRA](https://tickets.puppetlabs.com/browse/PCP)
+with the component `clj-pcp-client` for tickets on `puppetlabs/pcp-client`.


### PR DESCRIPTION
Here we add a CONTRIBUTING.md, a forward reference to our issue tracker to the
README.md, and make the CHANGELOG.md follow the same format as that established
by trapperkeeper-webserver-jetty9 in preparation of being an official
PuppetLabs open library.