### PR TITLE
(maint) revisit times tested for connection re-attempts

### DIFF
--- a/src/puppetlabs/pcp/client.clj
+++ b/src/puppetlabs/pcp/client.clj
@@ -148,7 +148,7 @@
   (let [{:keys [server websocket-client state should-stop]} client
         initial-sleep 200
         sleep-multiplier 2
-        maximum-sleep (* 30 1000)]
+        maximum-sleep (* 15 1000)]
     (reset! state :connecting)
     (loop [retry-sleep initial-sleep]
       (or (try+

--- a/test/puppetlabs/pcp/messaging_test.clj
+++ b/test/puppetlabs/pcp/messaging_test.clj
@@ -84,8 +84,9 @@
       app
       [broker-service jetty9-service webrouting-service metrics-service]
       broker-config
-      (client/wait-for-connection client 10000)
+      (client/wait-for-connection client (* 40 1000))
       (is (client/open? client) "Should now be connected"))
+    ;; allow the broker having gone down to be detected
     (Thread/sleep 1000)
     (is (not (client/open? client)) "Shoud be disconnected")))
 
@@ -101,12 +102,12 @@
       app
       [broker-service jetty9-service webrouting-service metrics-service]
       broker-config
-      (client/wait-for-connection client 10000)
+      (client/wait-for-connection client (* 40 1000))
       (is (client/open? client) "Should now be connected"))
     (is (not (client/open? client)) "Should be disconnected")
     (with-app-with-config
       app
       [broker-service jetty9-service webrouting-service metrics-service]
       broker-config
-      (client/wait-for-connection client 10000)
+      (client/wait-for-connection client (* 40 1000))
       (is (client/open? client) "Should be reconnected"))))


### PR DESCRIPTION
When testing our ability to connect to a previously downed broker
we were being too eager in declaring this a failure.  With this
commit we reduce the maximum reconnect delay to 15 seconds, and
then wait twice that time and a little more (40 seconds up from 10)
to see if we did manage to connect to a broker that was previously
down.

This will reduce races in detecting connection success as we saw
in build #14, where we can see the test failure being declared and
interleaved with the successful connection it was looking for:

    2015-10-07 06:56:14,704 DEBUG [p.p.client] Making connection to wss://localhost:8143/pcp/

    lein test :only puppetlabs.pcp.messaging-test/connect-to-a-down-up-down-up-broker-test

    FAIL in (connect-to-a-down-up-down-up-broker-test) (messaging_test.clj:105)
    Should now be connected
    expected: (client/open? client)
    2015-10-07 06:56:15,864 DEBUG [p.p.client] WebSocket connected
    actual: (not (client/open? #puppetlabs.pcp.client.Client{:server "wss://localhost:8143/pcp/", :identity "pcp://client01.example.com/demo-client", :state #<Atom@1d1d91c5: :connecting>, :handlers {"example/any_schema" #<core$constantly$fn__4085 clojure.core$constantly$fn__4085@12fbcc23>, :default #<messaging_test$default_request_handler puppetlabs.pcp.messaging_test$default_request_handler@430c5a2e>}, :should-stop #<core$promise$reify__6363@1a33ead8: :pending>, :websocket-connection #<Atom@467f1858: #<core$future_call$reify__6320@42433dc1: #<core$connect_with_client$reify__604 gniazdo.core$connect_with_client$reify__604@1e43ce6>>>, :websocket-client #<WebSocketClient org.eclipse.jetty.websocket.client.WebSocketClient@b322d15>}))
    2015-10-07 06:56:15,868 INFO  [p.p.b.service] Shutting down broker service