### PR TITLE
PCP-59 remove :state atom, determine state by inspection

### DIFF
--- a/test/puppetlabs/pcp/messaging_test.clj
+++ b/test/puppetlabs/pcp/messaging_test.clj
@@ -78,36 +78,36 @@
 
 (deftest connect-to-a-down-broker-test
   (with-open [client (connect-client "client01" (constantly true))]
-    (is (not (client/open? client)) "Should not be connected yet")
+    (is (not (client/connected? client)) "Should not be connected yet")
     (with-app-with-config
       app
       [broker-service jetty9-service webrouting-service metrics-service]
       broker-config
       (client/wait-for-connection client (* 40 1000))
-      (is (client/open? client) "Should now be connected"))
-    (is (not (client/open? client)) "Should be disconnected")))
+      (is (client/connected? client) "Should now be connected"))
+    (is (not (client/connected? client)) "Should be disconnected")))
 
 (deftest send-when-not-connected-test
   (with-open [client (connect-client "client01" (constantly true))]
-    (is (thrown+? [:type :puppetlabs.pcp.client/not-connected]
+    (is (thrown+? [:type :puppetlabs.pcp.client/not-associated]
                   (client/send! client (message/make-message))))))
 
 (deftest connect-to-a-down-up-down-up-broker-test
   (with-open [client (connect-client "client01" (constantly true))]
-    (is (not (client/open? client)) "Should not be connected yet")
+    (is (not (client/connected? client)) "Should not be connected yet")
     (with-app-with-config
       app
       [broker-service jetty9-service webrouting-service metrics-service]
       broker-config
       (client/wait-for-connection client (* 40 1000))
-      (is (client/open? client) "Should now be connected"))
-    (is (not (client/open? client)) "Should be disconnected")
+      (is (client/connected? client) "Should now be connected"))
+    (is (not (client/connected? client)) "Should be disconnected")
     (with-app-with-config
       app
       [broker-service jetty9-service webrouting-service metrics-service]
       broker-config
       (client/wait-for-connection client (* 40 1000))
-      (is (client/open? client) "Should be reconnected"))))
+      (is (client/connected? client) "Should be reconnected"))))
 
 (deftest association-checkers-test
   (with-app-with-config
@@ -116,5 +116,5 @@
     broker-config
     (with-open [client (connect-client "client01" (constantly true))]
       (is (= client (client/wait-for-association client (* 40 1000))))
-      (is (= true (client/associate-response-received? client)))
+      (is (= false (client/associating? client)))
       (is (= true (client/associated? client))))))


### PR DESCRIPTION
Here we rework the way we track state, eliminating some duplicate state
tracking that was causing race conditions.

Now we can reliably see if a client is connected by checking the state of the
future in the :websocket-connection atom, and the state of association by
checking the promise in the :associate-response atom.

We remove the additional states of :closing and :closed, rename open? to
connected? and so now just support `connecting?` `connected?` `associating?`
`associated?` to inspect client state.