### PR TITLE
PCP-47 deploy to clojars

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: clojure
+sudo: false
+lein: lein2
+jdk:
+  - oraclejdk7
+  - openjdk7
+script: lein2 test
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,21 +1,16 @@
-# clj-pcp-client
+## clj-pcp-client
 
 PCP client
 
 https://github.com/puppetlabs/pcp-specifications
 
+## Installation
 
-# Installation
+Releases of this project are distributed via clojars, to use it:
 
-The jar is distributed via the internal nexus server, to use it add
-the following to your project.clj
+[![Clojars Project](http://clojars.org/puppetlabs/pcp-client/latest-version.svg)](http://clojars.org/puppetlabs/pcp-client)
 
-    :dependencies [[puppetlabs/pcp-client "0.0.2"]]
-
-    :repositories [["releases" "http://nexus.delivery.puppetlabs.net/content/repositories/releases/"]
-                   ["snapshots" "http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/"]]
-
-# Usage example
+## Usage example
 
 ```clojure
 (ns example-client
@@ -69,7 +64,7 @@ the following to your project.clj
 (client/close conn)
 ```
 
-# Support
+## Support
 
 We use the [Puppet Communications Protocol project on JIRA](https://tickets.puppetlabs.com/browse/PCP)
 with the component `clj-pcp-client` for tickets on `puppetlabs/pcp-client`.

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,3 @@
-(defn deploy-info
-  [url]
-  {:url url
-   :username :env/nexus_jenkins_username
-   :password :env/nexus_jenkins_password
-   :sign-releases false})
-
 (defproject puppetlabs/pcp-client "0.1.1-SNAPSHOT"
   :description "client library for PCP"
   :url "https://github.com/puppetlabs/clj-pcp-client"
@@ -17,12 +10,14 @@
                  [org.clojure/tools.logging "0.3.1"]
                  [prismatic/schema "0.4.3"]
 
-                 ;; Transitive dependency for puppetlabs/ssl-utils and
-                 ;; puppetlabs/pcp-common
-                 [clj-time "0.9.0"]
+                 ;; Transitive dependency for:
+                 ;;  - puppetlabs/ssl-utils
+                 ;;  - puppetlabs/pcp-common
+                 ;;  - puppetlabs/trapperkeeper-authorization (via puppetlabs/pcp-broker)
+                 [clj-time "0.10.0"]
 
                  [puppetlabs/ssl-utils "0.8.1"]
-                 [puppetlabs/pcp-common "0.4.1"]
+                 [puppetlabs/pcp-common "0.5.0"]
 
                  ;; Transitive dependencies on jetty for stylefuits/gniazdo
                  ;; to use a stable jetty release (gniazdo specifies 9.3.0M1)
@@ -35,17 +30,17 @@
 
   :plugins [[lein-release "1.0.5" :exclusions [org.clojure/clojure]]]
 
-  :repositories [["releases" "http://nexus.delivery.puppetlabs.net/content/repositories/releases/"]
-                 ["snapshots"  "http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/"]]
+  :lein-release {:scm :git
+                 :deploy-via :lein-deploy}
 
-  :deploy-repositories [["releases" ~(deploy-info "http://nexus.delivery.puppetlabs.net/content/repositories/releases/")]
-                        ["snapshots" ~(deploy-info "http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/")]]
-
-  :lein-release {:scm :git, :deploy-via :lein-deploy}
+  :deploy-repositories [["releases" {:url "https://clojars.org/repo"
+                                     :username :env/clojars_jenkins_username
+                                     :password :env/clojars_jenkins_password
+                                     :sign-releases false}]]
 
   :test-paths ["test" "test-resources"]
 
-  :profiles {:dev {:dependencies [[puppetlabs/pcp-broker "0.2.2"]
+  :profiles {:dev {:dependencies [[puppetlabs/pcp-broker "0.5.0"]
                                   [puppetlabs/trapperkeeper "1.1.1" :classifier "test" :scope "test"]
                                   [puppetlabs/kitchensink "1.1.0" :classifier "test" :scope "test"]]}
              :cljfmt {:plugins [[lein-cljfmt "0.3.0"]


### PR DESCRIPTION
Here we change our project to deploy to clojars, consume public components, and add travis to help us verify.