### PR TITLE
PCP-346 Add a user-data field to the clj-pcp-client

### DIFF
--- a/test/puppetlabs/pcp/client_test.clj
+++ b/test/puppetlabs/pcp/client_test.clj
@@ -6,14 +6,22 @@
 
 (defn make-test-client
   "A dummied up client object"
-  []
-  (map->Client {:server "wss://localhost:8142/pcp/v1"
-                :identity "pcp://the_identity/the_type"
-                :websocket-client ""
-                :websocket-connection (atom (future true))
-                :associate-response (atom (promise))
-                :handlers {}
-                :should-stop (promise)}))
+  ([user-data]
+   (map->Client {:server "wss://localhost:8142/pcp/v1"
+                 :identity "pcp://the_identity/the_type"
+                 :websocket-client ""
+                 :websocket-connection (atom (future true))
+                 :associate-response (atom (promise))
+                 :handlers {}
+                 :should-stop (promise)
+                 :user-data user-data}))
+  ([]
+   (make-test-client nil)))
+
+(deftest client-with-user-data-test
+  (let [client (make-test-client "foo")]
+    (testing "client includes the user data"
+      (is (= (:user-data client) "foo")))))
 
 (deftest state-checkers-test
   (let [client (make-test-client)]


### PR DESCRIPTION
In this commit we add the option to include a ```:user-data``` field in the ```puppetlabs.pcp.client/Client``` defrecord. The filed is not used by the ```clj-pcp-client``` at all, it is meant to be used by the users of the client.