### PR TITLE
(PCP-480) Make max binary message size configurable

### DIFF
--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -57,6 +57,7 @@ msgstr ""
 msgid "WebSocket error"
 msgstr ""
 
+#. Format error code as a simple string (rather than localized).
 #: src/puppetlabs/pcp/client.clj
 msgid "WebSocket closed {0} {1}"
 msgstr ""

--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,7 @@
                  [clj-time "0.10.0"]
 
                  [puppetlabs/ssl-utils "0.8.1"]
-                 [puppetlabs/pcp-common "0.5.0"]
+                 [puppetlabs/pcp-common "0.5.1"]
 
                  ;; Transitive dependencies on jetty for stylefuits/gniazdo
                  ;; to use a stable jetty release (gniazdo specifies 9.3.0M1)

--- a/test/puppetlabs/pcp/messaging_test.clj
+++ b/test/puppetlabs/pcp/messaging_test.clj
@@ -173,3 +173,13 @@
       (is (= client (client/wait-for-association client (* 40 1000))))
       (is (= false (client/associating? client)))
       (is (= true (client/associated? client))))))
+
+(deftest connect-with-too-small-message-size
+  (with-app-with-config
+    app
+    [authorization-service broker-service jetty9-service webrouting-service metrics-service]
+    broker-config
+    (with-open [client (connect-client-config (assoc (client-config "client01")
+                                                     :max-message-size 128)
+                                              (constantly true))]
+      (is (= nil (client/wait-for-association client 1000))))))


### PR DESCRIPTION
In PCP version 1,  responses (such as `inventory_response`) can exceed
the default max message size in WebSockets (64KB). Make the max message
size configurable, so clients can determine how large a message they'd
like to handle.