### PR TITLE
(PCP-488) Disable schema validations by default

### DIFF
--- a/dev-resources/Makefile.i18n
+++ b/dev-resources/Makefile.i18n
@@ -19,6 +19,11 @@ LOCALES=$(basename $(notdir $(wildcard locales/*.po)))
 BUNDLE_DIR=$(subst .,/,$(BUNDLE))
 BUNDLE_FILES=$(patsubst %,resources/$(BUNDLE_DIR)/Messages_%.class,$(MESSAGE_LOCALE) $(LOCALES))
 FIND_SOURCES=find src -name \*.clj
+# xgettext before 0.19 does not understand --add-location=file. Even CentOS
+# 7 ships with an older gettext. We will therefore generate full location
+# info on those systems, and only file names where xgettext supports it
+LOC_OPT=$(shell xgettext --add-location=file -f - </dev/null >/dev/null 2>&1 && echo --add-location=file || echo --add-location)
+
 LOCALES_CLJ=resources/locales.clj
 define LOCALES_CLJ_CONTENTS
 {
@@ -36,24 +41,29 @@ i18n: update-pot msgfmt
 update-pot: locales/messages.pot
 
 locales/messages.pot: $(shell $(FIND_SOURCES)) | locales
-	@tmp=$(mktemp $@.tmp.XXXX);                                        \
-	$(FIND_SOURCES)                                                    \
-	    | xgettext --from-code=UTF-8 --language=lisp                   \
-	               --copyright-holder 'Puppet <docs@puppet.com>' -F    \
-	               --package-name "$(BUNDLE)"                          \
-	               --package-version "$(BUNDLE_VERSION)"               \
-	               --msgid-bugs-address "docs@puppet.com"              \
-	               -ktrs:1 -ki18n/trs:1                                \
-	               -ktru:1 -ki18n/tru:1                                \
-	               -ktrun:1,2 -ki18n/trun:1,2                          \
-	               -ktrsn:1,2 -ki18n/trsn:1,2                          \
-	               --add-comments -o $tmp -f -;                        \
-	sed -i -e 's/charset=CHARSET/charset=UTF-8/' $tmp;                 \
-	sed -i -e 's/POT-Creation-Date: [^\\]*/POT-Creation-Date: /' $tmp; \
-	if ! diff -q -I POT-Creation-Date $tmp $@ >& /dev/null; then       \
-	    mv $tmp $@;                                                    \
-	else                                                               \
-	    rm $tmp;                                                       \
+	@tmp=$$(mktemp $@.tmp.XXXX);                                            \
+	$(FIND_SOURCES)                                                         \
+	    | xgettext --from-code=UTF-8 --language=lisp                        \
+	               --copyright-holder='Puppet <docs@puppet.com>'            \
+	               --package-name="$(BUNDLE)"                               \
+	               --package-version="$(BUNDLE_VERSION)"                    \
+	               --msgid-bugs-address="docs@puppet.com"                   \
+	               -k                                                       \
+	               -kmark:1 -ki18n/mark:1                                   \
+	               -ktrs:1 -ki18n/trs:1                                     \
+	               -ktru:1 -ki18n/tru:1                                     \
+	               -ktrun:1,2 -ki18n/trun:1,2                               \
+	               -ktrsn:1,2 -ki18n/trsn:1,2                               \
+	               $(LOC_OPT)                                               \
+	               --add-comments --sort-by-file                            \
+	               -o $$tmp -f -;                                           \
+	sed -i.bak -e 's/charset=CHARSET/charset=UTF-8/' $$tmp;                 \
+	sed -i.bak -e 's/POT-Creation-Date: [^\\]*/POT-Creation-Date: /' $$tmp; \
+	rm -f $$tmp.bak;                                                        \
+	if ! diff -q -I POT-Creation-Date $$tmp $@ >/dev/null 2>&1; then        \
+	    mv $$tmp $@;                                                        \
+	else                                                                    \
+	    rm $$tmp; touch $@;                                                 \
 	fi
 
 # Run msgfmt over all .po files to generate Java resource bundles

--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -17,72 +17,72 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/puppetlabs/pcp/client.clj:124
+#: src/puppetlabs/pcp/client.clj
 msgid "Received associate_response message {0} {1}"
 msgstr ""
 
-#: src/puppetlabs/pcp/client.clj:130
+#: src/puppetlabs/pcp/client.clj
 msgid "No handler for {0}"
 msgstr ""
 
-#: src/puppetlabs/pcp/client.clj:159
+#: src/puppetlabs/pcp/client.clj
 msgid "Sending WebSocket ping"
 msgstr ""
 
-#: src/puppetlabs/pcp/client.clj:162
+#: src/puppetlabs/pcp/client.clj
 msgid "WebSocket heartbeat task is about to finish"
 msgstr ""
 
-#: src/puppetlabs/pcp/client.clj:169
+#: src/puppetlabs/pcp/client.clj
 msgid "Ensuring that the WebSocket is connected"
 msgstr ""
 
-#: src/puppetlabs/pcp/client.clj:172
+#: src/puppetlabs/pcp/client.clj
 msgid "WebSocket heartbeat task is about to start {0}"
 msgstr ""
 
-#: src/puppetlabs/pcp/client.clj:187
+#: src/puppetlabs/pcp/client.clj
 msgid "Making connection to {0}"
 msgstr ""
 
-#: src/puppetlabs/pcp/client.clj:191
+#: src/puppetlabs/pcp/client.clj
 msgid "WebSocket connected"
 msgstr ""
 
-#: src/puppetlabs/pcp/client.clj:195
+#: src/puppetlabs/pcp/client.clj
 msgid "Sent associate session request"
 msgstr ""
 
-#: src/puppetlabs/pcp/client.clj:197
+#: src/puppetlabs/pcp/client.clj
 msgid "WebSocket error"
 msgstr ""
 
-#: src/puppetlabs/pcp/client.clj:199
+#: src/puppetlabs/pcp/client.clj
 msgid "WebSocket closed {0} {1}"
 msgstr ""
 
-#: src/puppetlabs/pcp/client.clj:205
+#: src/puppetlabs/pcp/client.clj
 msgid "Received text message"
 msgstr ""
 
-#: src/puppetlabs/pcp/client.clj:209
+#: src/puppetlabs/pcp/client.clj
 msgid "Received bin message - offset/bytes: {0}/{1} - message: {2}"
 msgstr ""
 
-#: src/puppetlabs/pcp/client.clj:213
+#: src/puppetlabs/pcp/client.clj
 msgid "TLS Handshake failed.  Sleeping for up to {0}ms to retry"
 msgstr ""
 
 #. The following will produce "Didn't get connected.  ..."
 #. The apostrophe needs to be duplicated (enven in the translations).
-#: src/puppetlabs/pcp/client.clj:218
+#: src/puppetlabs/pcp/client.clj
 msgid "Didn''t get connected.  Sleeping for up to {0}ms to retry"
 msgstr ""
 
-#: src/puppetlabs/pcp/client.clj:221
+#: src/puppetlabs/pcp/client.clj
 msgid "Unexpected error"
 msgstr ""
 
-#: src/puppetlabs/pcp/client.clj:258
+#: src/puppetlabs/pcp/client.clj
 msgid "Closing"
 msgstr ""

--- a/project.clj
+++ b/project.clj
@@ -1,3 +1,5 @@
+(def i18n-version "0.4.1")
+
 (defproject puppetlabs/pcp-client "0.3.1-SNAPSHOT"
   :description "client library for PCP"
   :url "https://github.com/puppetlabs/clj-pcp-client"
@@ -28,10 +30,10 @@
                  ;; try+/throw+
                  [slingshot "0.12.2"]
 
-                 [puppetlabs/i18n "0.3.0"]]
+                 [puppetlabs/i18n  ~i18n-version]]
 
   :plugins [[lein-release "1.0.5" :exclusions [org.clojure/clojure]]
-            [puppetlabs/i18n "0.3.0"]]
+            [puppetlabs/i18n  ~i18n-version]]
 
   :lein-release {:scm :git
                  :deploy-via :lein-deploy}

--- a/test/puppetlabs/pcp/client_test.clj
+++ b/test/puppetlabs/pcp/client_test.clj
@@ -2,7 +2,10 @@
   (:require [clojure.test :refer :all]
             [puppetlabs.pcp.client :refer :all :as client]
             [puppetlabs.pcp.message :as message]
-            [slingshot.test]))
+            [slingshot.test]
+            [schema.test :as st]))
+
+(use-fixtures :once st/validate-schemas)
 
 (defn make-test-client
   "A dummied up client object"

--- a/test/puppetlabs/pcp/messaging_test.clj
+++ b/test/puppetlabs/pcp/messaging_test.clj
@@ -11,7 +11,8 @@
             [puppetlabs.trapperkeeper.testutils.bootstrap :refer [with-app-with-config]]
             [puppetlabs.trapperkeeper.testutils.logging
              :refer [with-test-logging with-test-logging-debug]]
-            [slingshot.test]))
+            [slingshot.test]
+            [schema.test :as st]))
 
 (def broker-config
   "A broker with ssl and own spool"
@@ -34,11 +35,14 @@
    :web-router-service {:puppetlabs.pcp.broker.service/broker-service {:websocket "/pcp"
                                                                        :metrics "/"}}
 
-   :metrics {:enabled true}
+   :metrics {:enabled true
+             :server-id "localhost"}
 
    :pcp-broker {:broker-spool "test-resources/tmp/spool"
                 :accept-consumers 2
                 :delivery-consumers 2}})
+
+(use-fixtures :once st/validate-schemas)
 
 (defn default-request-handler
   [conn request]


### PR DESCRIPTION
This commit removes the `^:always-validate` attribute from all functions in this projects which used it in order to disable the schema validation for those functions by default.
To compensate for that the tests in this project now use the `schema.test/validate-schemas` fixture so that they still run with the validations enabled.