### PR TITLE
(maint) Fix race condition in tests

### DIFF
--- a/test/puppetlabs/pcp/client_test.clj
+++ b/test/puppetlabs/pcp/client_test.clj
@@ -10,14 +10,16 @@
 (defn make-test-client
   "A dummied up client object"
   ([user-data]
-   (map->Client {:server "wss://localhost:8142/pcp/v1"
-                 :identity "pcp://the_identity/the_type"
-                 :websocket-client ""
-                 :websocket-connection (atom (future true))
-                 :associate-response (atom (promise))
-                 :handlers {}
-                 :should-stop (promise)
-                 :user-data user-data}))
+   (let [realized-future (future true)]
+     (deref realized-future)                                ; make sure the future is realized
+     (map->Client {:server "wss://localhost:8142/pcp/v1"
+                   :identity "pcp://the_identity/the_type"
+                   :websocket-client ""
+                   :websocket-connection (atom realized-future)
+                   :associate-response (atom (promise))
+                   :handlers {}
+                   :should-stop (promise)
+                   :user-data user-data})))
   ([]
    (make-test-client nil)))
 


### PR DESCRIPTION
The state of a dummy PCP client used by some tests in this project was racy as it contained a `(future )` field which may have or may have not been realized at the time the tests were testing it, which was causing occasional test failures.
This commit makes sure the state of the dummy PCP client is stable (i.e. its `(future )` field is realized) before its handed over to the tests.