### PR TITLE
(maint) Assert websocket too large message is logged

### DIFF
--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -57,7 +57,7 @@ msgstr ""
 msgid "WebSocket error"
 msgstr ""
 
-#. Format error code as a simple string (rather than localized).
+#. Format error code as a string rather than a localized number, i.e. 1,234.
 #: src/puppetlabs/pcp/client.clj
 msgid "WebSocket closed {0} {1}"
 msgstr ""

--- a/project.clj
+++ b/project.clj
@@ -46,7 +46,8 @@
   :test-paths ["test" "test-resources"]
 
   :profiles {:dev {:dependencies [[puppetlabs/pcp-broker "0.5.0"]
-                                  [puppetlabs/trapperkeeper "1.1.1" :classifier "test" :scope "test"]
+                                  [puppetlabs/trapperkeeper "1.1.2"]
+                                  [puppetlabs/trapperkeeper "1.1.2" :classifier "test" :scope "test"]
                                   [puppetlabs/kitchensink "1.1.0" :classifier "test" :scope "test"]]}
              :cljfmt {:plugins [[lein-cljfmt "0.3.0"]
                                 [lein-parent "0.2.1"]]

--- a/src/puppetlabs/pcp/client.clj
+++ b/src/puppetlabs/pcp/client.clj
@@ -196,7 +196,7 @@
                         :on-error (fn [error]
                                     (log/error error (i18n/trs "WebSocket error")))
                         :on-close (fn [code message]
-                                    ;; Format error code as a simple string (rather than localized).
+                                    ;; Format error code as a string rather than a localized number, i.e. 1,234.
                                     (log/debug (i18n/trs "WebSocket closed {0} {1}" (str code) message))
                                     (reset! associate-response (promise))
                                     (let [{:keys [should-stop websocket-connection]} client]


### PR DESCRIPTION
Asserts that testing receives a websocket message that's larger than the
configured limit.