### PR TITLE
(PCP-518) Add delay between each reconnect attempt after close

### DIFF
--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -63,6 +63,10 @@ msgid "WebSocket closed {0} {1}"
 msgstr ""
 
 #: src/puppetlabs/pcp/client.clj
+msgid "Sleeping for up to {0} ms to retry"
+msgstr ""
+
+#: src/puppetlabs/pcp/client.clj
 msgid "Received text message"
 msgstr ""
 
@@ -71,13 +75,13 @@ msgid "Received bin message - offset/bytes: {0}/{1} - message: {2}"
 msgstr ""
 
 #: src/puppetlabs/pcp/client.clj
-msgid "TLS Handshake failed.  Sleeping for up to {0}ms to retry"
+msgid "TLS Handshake failed.  Sleeping for up to {0} ms to retry"
 msgstr ""
 
 #. The following will produce "Didn't get connected.  ..."
-#. The apostrophe needs to be duplicated (enven in the translations).
+#. The apostrophe needs to be duplicated (even in the translations).
 #: src/puppetlabs/pcp/client.clj
-msgid "Didn''t get connected.  Sleeping for up to {0}ms to retry"
+msgid "Didn''t get connected.  Sleeping for up to {0} ms to retry"
 msgstr ""
 
 #: src/puppetlabs/pcp/client.clj

--- a/project.clj
+++ b/project.clj
@@ -1,3 +1,5 @@
+(def tk-version "1.4.0")
+(def ks-version "1.3.0")
 (def i18n-version "0.4.1")
 
 (defproject puppetlabs/pcp-client "0.3.2-SNAPSHOT"
@@ -10,7 +12,6 @@
 
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/tools.logging "0.3.1"]
-                 [prismatic/schema "0.4.3"]
 
                  ;; Transitive dependency for:
                  ;;  - puppetlabs/ssl-utils
@@ -19,7 +20,9 @@
                  [clj-time "0.10.0"]
 
                  [puppetlabs/ssl-utils "0.8.1"]
-                 [puppetlabs/pcp-common "0.5.1"]
+                 [puppetlabs/pcp-common "0.5.1" :exclusions [puppetlabs/kitchensink prismatic/schema]]
+                 [puppetlabs/kitchensink "1.3.0"]
+                 [prismatic/schema "1.0.4"]
 
                  ;; Transitive dependencies on jetty for stylefuits/gniazdo
                  ;; to use a stable jetty release (gniazdo specifies 9.3.0M1)
@@ -45,10 +48,10 @@
 
   :test-paths ["test" "test-resources"]
 
-  :profiles {:dev {:dependencies [[puppetlabs/pcp-broker "0.5.0"]
-                                  [puppetlabs/trapperkeeper "1.1.2"]
-                                  [puppetlabs/trapperkeeper "1.1.2" :classifier "test" :scope "test"]
-                                  [puppetlabs/kitchensink "1.1.0" :classifier "test" :scope "test"]]}
+  :profiles {:dev {:dependencies [[puppetlabs/pcp-broker "0.7.1"]
+                                  [puppetlabs/trapperkeeper ~tk-version]
+                                  [puppetlabs/trapperkeeper ~tk-version :classifier "test" :scope "test"]
+                                  [puppetlabs/kitchensink ~ks-version :classifier "test" :scope "test"]]}
              :cljfmt {:plugins [[lein-cljfmt "0.3.0"]
                                 [lein-parent "0.2.1"]]
                       :parent-project {:path "../pl-clojure-style/project.clj"

--- a/test-resources/logback.xml
+++ b/test-resources/logback.xml
@@ -11,6 +11,6 @@
 
     <logger name="log4j.logger.org.eclipse.jetty.server" level="warn"/>
     <logger name="log4j.logger.org.eclipse.jetty.util.log" level="warn"/>
-    <logger name="puppetlabs.pcp.client" level="debug"/>
+    <logger name="puppetlabs.pcp.client" level="info"/>
     <logger name="puppetlabs.pcp.broker" level="info"/>
 </configuration>

--- a/test/puppetlabs/pcp/messaging_test.clj
+++ b/test/puppetlabs/pcp/messaging_test.clj
@@ -10,7 +10,7 @@
             [puppetlabs.trapperkeeper.services.webserver.jetty9-service :refer [jetty9-service]]
             [puppetlabs.trapperkeeper.testutils.bootstrap :refer [with-app-with-config]]
             [puppetlabs.trapperkeeper.testutils.logging
-             :refer [with-test-logging with-test-logging-debug]]
+             :refer [with-log-level with-test-logging with-test-logging-debug]]
             [slingshot.test]
             [schema.test :as st]))
 
@@ -185,9 +185,10 @@
       ; Stop the client immediately, but don't trigger on-close. This attempts to limit to only
       ; one association attempt.
       (deliver (:should-stop client) true)
-      (with-test-logging-debug
-        (let [connected (client/wait-for-connection client 4000)
-              associated (client/wait-for-association client 1000)]
-          (is connected)
-          (is (not associated))
-          (is (logged? #"WebSocket closed 1009 Binary message size \[289\] exceeds maximum size \[128\]" :debug)))))))
+      (with-log-level "puppetlabs.pcp.client" :debug
+        (with-test-logging
+          (let [connected (client/wait-for-connection client 4000)
+                associated (client/wait-for-association client 1000)]
+            (is connected)
+            (is (not associated))
+            (is (logged? #"WebSocket closed 1009 Binary message size \[289\] exceeds maximum size \[128\]" :debug))))))))


### PR DESCRIPTION
Avoid flooding the broker with connections during startup/shutdown when pcp-client is active. This seems to make tests with broker startup/shutdown more reliable.

Also bump to pcp-broker 0.7.1, extract service config to a variable, and reduce logging during testing.