### PR TITLE
(PCP-537, PCP-535) Report disconnected immediately on connection close, don't enable schema during testing

### DIFF
--- a/test/puppetlabs/pcp/client_test.clj
+++ b/test/puppetlabs/pcp/client_test.clj
@@ -5,8 +5,6 @@
             [slingshot.test]
             [schema.test :as st]))
 
-(use-fixtures :once st/validate-schemas)
-
 (defn make-test-client
   "A dummied up client object"
   ([user-data]

--- a/test/puppetlabs/pcp/messaging_test.clj
+++ b/test/puppetlabs/pcp/messaging_test.clj
@@ -105,10 +105,10 @@
   (with-open [client (connect-client "client01" (constantly true))]
     (is (not (client/connected? client)) "Should not be connected yet")
     (with-app-with-config app broker-services broker-config
-      (is (client/wait-for-connection client (* 40 1000)))
+      (client/wait-for-connection client (* 40 1000))
       (is (client/connected? client) "Should now be connected"))
-    ;; wait the retry-sleep period before checking for disconnect
-    (Thread/sleep 200)
+    ;; Allow time for the websocket connection to close, but not enough to attempt reconnecting
+    (Thread/sleep 1)
     (is (not (client/connected? client)) "Should be disconnected")))
 
 (deftest connect-to-a-broker-with-the-wrong-name-test
@@ -150,13 +150,13 @@
   (with-open [client (connect-client "client01" (constantly true))]
     (is (not (client/connected? client)) "Should not be connected yet")
     (with-app-with-config app broker-services broker-config
-      (is (client/wait-for-connection client (* 40 1000)))
+      (client/wait-for-connection client (* 40 1000))
       (is (client/connected? client) "Should now be connected"))
-    ;; wait the retry-sleep period before checking for disconnect
-    (Thread/sleep 200)
+    ;; Allow time for the websocket connection to close, but not enough to attempt reconnecting
+    (Thread/sleep 1)
     (is (not (client/connected? client)) "Should be disconnected")
     (with-app-with-config app broker-services broker-config
-      (is (client/wait-for-connection client (* 40 1000)))
+      (client/wait-for-connection client (* 40 1000))
       (is (client/connected? client) "Should be reconnected"))))
 
 (deftest association-checkers-test

--- a/test/puppetlabs/pcp/messaging_test.clj
+++ b/test/puppetlabs/pcp/messaging_test.clj
@@ -46,8 +46,6 @@
                 :accept-consumers 2
                 :delivery-consumers 2}})
 
-(use-fixtures :once st/validate-schemas)
-
 (defn default-request-handler
   [conn request]
   (log/debug "Default handler got message" request))


### PR DESCRIPTION
Restores reporting disconnected immediately after the connection is
closed. Previously - after PCP-518 - the connection would report
connected while waiting to try re-establishing the connection.

Schema checks may be incorrectly used to verify API behavior. Ensure we
run some testing without all schemas enabled to verify correct behavior.