### PR TITLE
(PCP-544) Make client operations more reliable

### DIFF
--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -18,6 +18,10 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: src/puppetlabs/pcp/client.clj
+msgid "exception while establishing a connection; not connected"
+msgstr ""
+
+#: src/puppetlabs/pcp/client.clj
 msgid "Received associate_response message {0} {1}"
 msgstr ""
 
@@ -89,9 +93,27 @@ msgid "Didn''t get connected. Sleeping for up to {0} ms to retry"
 msgstr ""
 
 #: src/puppetlabs/pcp/client.clj
+msgid ""
+"Connection closed while establishing connection. Sleeping for up to {0} ms "
+"to reconnect"
+msgstr ""
+
+#: src/puppetlabs/pcp/client.clj
 msgid "Unexpected error"
 msgstr ""
 
 #: src/puppetlabs/pcp/client.clj
+msgid "exception while waiting for a connection; not connected"
+msgstr ""
+
+#: src/puppetlabs/pcp/client.clj
+msgid "exception on the connection while attempting to send a message"
+msgstr ""
+
+#: src/puppetlabs/pcp/client.clj
 msgid "Closing"
+msgstr ""
+
+#: src/puppetlabs/pcp/client.clj
+msgid "exception while closing the connection; connection already closed"
 msgstr ""

--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,7 @@
                  [clj-time "0.10.0"]
 
                  [puppetlabs/ssl-utils "0.8.1"]
-                 [puppetlabs/pcp-common "0.5.1" :exclusions [puppetlabs/kitchensink prismatic/schema]]
+                 [puppetlabs/pcp-common "0.5.2" :exclusions [puppetlabs/kitchensink prismatic/schema]]
                  [puppetlabs/kitchensink "1.3.0"]
                  [prismatic/schema "1.0.4"]
 

--- a/test-resources/logback-test.xml
+++ b/test-resources/logback-test.xml
@@ -1,0 +1,14 @@
+<configuration scan="true">
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d %-5p [%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="error">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <logger name="puppetlabs.pcp.client" level="warn"/>
+    <logger name="puppetlabs.pcp.broker" level="warn"/>
+</configuration>


### PR DESCRIPTION
Catches exceptions that occur while trying to establish a connection or
operate on a connection. Connections can be unexpectedly closed at any
time, and our public APIs should handle failures appropriately.

Specifically we move to catching execution exceptions when dereferencing
the websocket-connection. It seems like we have a few cases:
- `connected?` and `wait-for-connection` catch the exceptions and return
  appropriately (`connected?` returns false if an exception occured, and
  `wait-for-connection` returns nil signifying no connection was
  established)
- `send!` throws a not-connected exception wrapping the original failure
- `close` catches and swallows (logs) failure, as it's not supposed to
  attempt supposed to attempt to close the websocket-connection if not
  connected

Also catch EofException, which can happen when attempting to `sendBytes`
for Session Association and the connection unexpectedly closes.