### PR TITLE
(PCP-652) adapt client to support PCP v2

### DIFF
--- a/examples/README.clj
+++ b/examples/README.clj
@@ -3,17 +3,16 @@
 (ns example-client
   (:require [clojure.tools.logging :as log]
             [puppetlabs.pcp.client :as client]
-            [puppetlabs.pcp.message :as message]))
+            [puppetlabs.pcp.message-v2 :as message]))
 
 (defn cnc-request-handler
   [conn request]
   (log/info "cnc handler got message" request)
   (let [response (-> (message/make-message)
-                     (assoc :targets [(:sender request)]
+                     (assoc :target (:sender request)
                             :message_type "example/cnc_response")
-                     (message/set-expiry 3 :seconds)
-                     (message/set-json-data {:response "Hello world"
-                                             :request (:id request)}))]
+                     (message/set-data {:response "Hello world"
+                                        :request (:id request)}))]
     (client/send! conn response))
   (log/info "cnc handler sent response"))
 
@@ -26,8 +25,7 @@
             {:server      "wss://localhost:8142/pcp/"
              :cert        "test-resources/ssl/certs/client03.example.com.pem"
              :private-key "test-resources/ssl/private_keys/client03.example.com.pem"
-             :cacert      "test-resources/ssl/certs/ca.pem"
-             :type        "demo_client"}
+             :cacert      "test-resources/ssl/certs/ca.pem"}
            {"example/cnc_request" cnc-request-handler
             :default default-request-handler}))
 
@@ -45,18 +43,16 @@
 
 (client/send! conn
               (-> (message/make-message)
-                  (message/set-expiry 3 :seconds)
-                  (assoc :targets ["pcp://*/demo-client"]
+                  (assoc :target "pcp://*/demo-client"
                          :message_type "example/any_schema")))
 
 (log/info "### sending example/cnc_request")
 
 (client/send! conn
               (-> (message/make-message)
-                  (message/set-expiry 3 :seconds)
-                  (assoc :targets ["pcp://*/demo-client"]
+                  (assoc :target "pcp://*/demo-client"
                          :message_type "example/cnc_request")
-                  (message/set-json-data {:action "demo"})))
+                  (message/set-data {:action "demo"})))
 
 ;; wait 5 seconds for things to resolve
 (Thread/sleep (* 5 1000))

--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -22,10 +22,6 @@ msgid "exception while establishing a connection; not connected"
 msgstr ""
 
 #: src/puppetlabs/pcp/client.clj
-msgid "Received associate_response message {0} {1}"
-msgstr ""
-
-#: src/puppetlabs/pcp/client.clj
 msgid "No handler for {0}"
 msgstr ""
 
@@ -58,10 +54,6 @@ msgid "WebSocket connected"
 msgstr ""
 
 #: src/puppetlabs/pcp/client.clj
-msgid "Sent associate session request"
-msgstr ""
-
-#: src/puppetlabs/pcp/client.clj
 msgid "WebSocket error"
 msgstr ""
 
@@ -76,10 +68,6 @@ msgstr ""
 
 #: src/puppetlabs/pcp/client.clj
 msgid "Received text message"
-msgstr ""
-
-#: src/puppetlabs/pcp/client.clj
-msgid "Received bin message - offset/bytes: {0}/{1} - message: {2}"
 msgstr ""
 
 #: src/puppetlabs/pcp/client.clj
@@ -104,6 +92,10 @@ msgstr ""
 
 #: src/puppetlabs/pcp/client.clj
 msgid "exception while waiting for a connection; not connected"
+msgstr ""
+
+#: src/puppetlabs/pcp/client.clj
+msgid "refusing to send message on unconnected session"
 msgstr ""
 
 #: src/puppetlabs/pcp/client.clj

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject puppetlabs/pcp-client "0.3.5-SNAPSHOT"
+(defproject puppetlabs/pcp-client "1.0.0-SNAPSHOT"
   :description "client library for PCP"
   :url "https://github.com/puppetlabs/clj-pcp-client"
   :license {:name "Apache License, Version 2.0"
@@ -11,7 +11,7 @@
   :parent-project {:coords [puppetlabs/clj-parent "0.3.0"]
                    :inherit [:managed-dependencies]}
 
-  :dependencies [[puppetlabs/pcp-common "0.5.4"]
+  :dependencies [[puppetlabs/pcp-common "1.0.0"]
 
                  ;; Transitive dependencies on jetty for stylefuits/gniazdo
                  ;; to use a stable jetty release (gniazdo specifies 9.3.0M1)
@@ -41,10 +41,11 @@
 
   :test-paths ["test" "test-resources"]
 
-  :profiles {:dev {:dependencies [[puppetlabs/pcp-broker "0.8.1" :exclusions [commons-logging]]
+  :profiles {:dev {:dependencies [[puppetlabs/pcp-broker "1.0.0" :exclusions [commons-logging]]
                                   [puppetlabs/trapperkeeper]
                                   [puppetlabs/trapperkeeper :classifier "test" :scope "test"]
-                                  [puppetlabs/kitchensink :classifier "test" :scope "test"]]}
+                                  [puppetlabs/kitchensink :classifier "test" :scope "test"]
+                                  [puppetlabs/trapperkeeper-webserver-jetty9 "1.6.0"]]}
              :cljfmt {:plugins [[lein-cljfmt "0.3.0"]
                                 [lein-parent "0.2.1"]]
                       :parent-project {:path "../pl-clojure-style/project.clj"


### PR DESCRIPTION
Adapt clj-pcp-client to support PCP v2 and drop support for PCP v1.

* drop usage of session association
* drop usage of message expiration
* switch to using v2 functions from pcp-commons
* update examples