### PR TITLE
(maint) Fix race in wait-for-connection

### DIFF
--- a/src/puppetlabs/pcp/client.clj
+++ b/src/puppetlabs/pcp/client.clj
@@ -93,6 +93,10 @@
   (let [{:keys [websocket-connection]} client]
     (not (realized? @websocket-connection))))
 
+(s/defn ^:private -connection-connected? :- s/Bool
+  [connection]
+  (and (realized? connection) (not (= @connection true))))
+
 (s/defn ^:private -connected? :- s/Bool
   [client :- Client]
   (let [{:keys [websocket-connection]} client]
@@ -100,7 +104,7 @@
     ;; this happens occasionally if the broker is starting up or shutting down
     ;; when we attempt to connect, or if the connection disappears abruptly
     (try
-      (and (realized? @websocket-connection) (not (= @@websocket-connection true)))
+      (-connection-connected? @websocket-connection)
       (catch java.util.concurrent.ExecutionException exception
         (log/debug exception (i18n/trs "exception while establishing a connection; not connected"))
         false))))
@@ -212,11 +216,12 @@
                                     (reset! associate-response (promise))
                                     (let [{:keys [should-stop websocket-connection]} client]
                                       ;; Ensure disconnect state is immediately registered as connecting.
-                                      (reset! websocket-connection (future (Thread/sleep (* sleep-multiplier retry-sleep))))
                                       (log/debug (i18n/trs "Sleeping for up to {0} ms to retry" retry-sleep))
-                                      (if-not (deref should-stop retry-sleep nil)
-                                        (reset! websocket-connection (future (make-connection client)))
-                                        (reset! websocket-connection (future true)))))
+                                      (reset! websocket-connection
+                                              (future
+                                                (if-not (deref should-stop initial-sleep nil)
+                                                  (make-connection client)
+                                                  true)))))
                         :on-receive (fn [text]
                                       (log/debug (i18n/trs "Received text message"))
                                       (dispatch-message client (message/decode (message/string->bytes text))))
@@ -285,11 +290,15 @@
   (let [{:keys [should-stop websocket-client websocket-connection]} client]
     ;; NOTE:  This true value is also the sentinel for make-connection
     (deliver should-stop true)
-    (if (-connected? client)
-      (try
-        (ws/close @@websocket-connection)
-        (catch java.util.concurrent.ExecutionException exception
-          (log/debug exception (i18n/trs "exception while closing the connection; connection already closed")))))
+    (try
+      ;; Make access to websocket-connection atomic, so we don't cause an exception when racing
+      ;; during shutdown. The websocket-connection atom could be reset to true between checking
+      ;; connected? and dereferencing the atom to close the connection.
+      (let [connection @websocket-connection]
+        (if (-connection-connected? connection)
+          (ws/close @connection)))
+      (catch java.util.concurrent.ExecutionException exception
+        (log/debug exception (i18n/trs "exception while closing the connection; connection already closed"))))
     (.stop websocket-client))
   true)
 

--- a/test/puppetlabs/pcp/messaging_test.clj
+++ b/test/puppetlabs/pcp/messaging_test.clj
@@ -160,17 +160,16 @@
 
 (deftest connect-to-a-down-up-down-up-broker-test
   (with-open [client (connect-client "client01" (constantly true))]
-    (with-log-level "puppetlabs.pcp.client" :debug
-      (is (not (client/connected? client)) "Should not be connected yet")
-      (with-app-with-config app broker-services broker-config
-        (client/wait-for-connection client (* 40 1000))
-        (is (client/connected? client) "Should now be connected"))
-      ;; Allow time for the websocket connection to close, but not enough to attempt reconnecting
-      (Thread/sleep 5)
-      (is (not (client/connected? client)) "Should be disconnected")
-      (with-app-with-config app broker-services broker-config
-        (client/wait-for-connection client (* 40 1000))
-        (is (client/connected? client) "Should be reconnected")))))
+    (is (not (client/connected? client)) "Should not be connected yet")
+    (with-app-with-config app broker-services broker-config
+      (client/wait-for-connection client (* 40 1000))
+      (is (client/connected? client) "Should now be connected"))
+    ;; Allow time for the websocket connection to close, but not enough to attempt reconnecting
+    (Thread/sleep 5)
+    (is (not (client/connected? client)) "Should be disconnected")
+    (with-app-with-config app broker-services broker-config
+      (client/wait-for-connection client (* 40 1000))
+      (is (client/connected? client) "Should be reconnected"))))
 
 (deftest association-checkers-test
   (with-app-with-config app broker-services broker-config

--- a/test/puppetlabs/pcp/messaging_test.clj
+++ b/test/puppetlabs/pcp/messaging_test.clj
@@ -113,7 +113,7 @@
       (client/wait-for-connection client (* 40 1000))
       (is (client/connected? client) "Should now be connected"))
     ;; Allow time for the websocket connection to close, but not enough to attempt reconnecting
-    (Thread/sleep 5)
+    (Thread/sleep 500)
     (is (not (client/connected? client)) "Should be disconnected")))
 
 (deftest connect-to-a-broker-with-the-wrong-name-test
@@ -162,13 +162,13 @@
   (with-open [client (connect-client "client01" (constantly true))]
     (is (not (client/connected? client)) "Should not be connected yet")
     (with-app-with-config app broker-services broker-config
-      (client/wait-for-connection client (* 40 1000))
+      (is (= client (client/wait-for-connection client (* 40 1000))))
       (is (client/connected? client) "Should now be connected"))
     ;; Allow time for the websocket connection to close, but not enough to attempt reconnecting
-    (Thread/sleep 5)
+    (Thread/sleep 500)
     (is (not (client/connected? client)) "Should be disconnected")
     (with-app-with-config app broker-services broker-config
-      (client/wait-for-connection client (* 40 1000))
+      (is (= client (client/wait-for-connection client (* 40 1000))))
       (is (client/connected? client) "Should be reconnected"))))
 
 (deftest association-checkers-test


### PR DESCRIPTION
When calling wait-for-connection after on-close has been called,
dereferencing the websocket-connection atom can return the future to a
sleep call. Waiting on that future will always wait the sleep period
and return nil. Change to using a single future for checking whether to
stop or retry connecting.