### PR TITLE
(PCP-700) Allow setting sender on messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.0.0
+
+This is a major feature release to support PCP v2. It drops support for PCP v1.
+
+* [PCP-700](https://tickets.puppetlabs.com/browse/PCP-700) Allow setting sender
+on messages.
+* [PCP-652](https://tickets.puppetlabs.com/browse/PCP-652) Switch to using PCP
+v2. Drops support for message expiration.
+
 ## 0.4.0
 
 This is a feature release to enable compatibility with pcp-broker 1.0. It

--- a/project.clj
+++ b/project.clj
@@ -21,7 +21,7 @@
                  [org.clojure/clojure]
                  [org.clojure/tools.logging]
                  [puppetlabs/ssl-utils]
-                 [puppetlabs/kitchensink]
+                 [puppetlabs/kitchensink "2.2.0"]
                  [prismatic/schema]
                  [puppetlabs/trapperkeeper-status]
                  [puppetlabs/trapperkeeper-scheduler]

--- a/src/puppetlabs/pcp/client.clj
+++ b/src/puppetlabs/pcp/client.clj
@@ -5,6 +5,7 @@
             [puppetlabs.pcp.protocol :as p]
             [puppetlabs.ssl-utils.core :as ssl-utils]
             [schema.core :as s]
+            [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.i18n.core :as i18n])
   (:use [slingshot.slingshot :only [throw+ try+]])
   (:import  (clojure.lang Atom)
@@ -210,7 +211,7 @@
           (throw+ {:type ::not-connected}))
       (try
         (ws/send-msg @@websocket-connection
-                     (message/encode (assoc message :sender identity)))
+                     (message/encode (ks/assoc-if-new message :sender identity)))
         (catch java.util.concurrent.ExecutionException exception
           (log/debug exception (i18n/trs "exception on the connection while attempting to send a message"))
           (throw+ {:type ::not-connected}))))


### PR DESCRIPTION
Avoid overwriting the sender when sending a message, to allow the sender
to relay messages from another entity. This won't work with pcp-broker,
but is useful in other scenarios.