### PR TITLE
(PCP-700) Support usage in pcp-broker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.0.0
+
+This is a major feature release to support PCP v2. It drops support for PCP v1.
+
+* [PCP-700](https://tickets.puppetlabs.com/browse/PCP-700) Support usage in
+pcp-broker. Specifically allow initializing from an SSLContext, handle the
+heartbeat thread internally, and don't set sender so messages can be relayed.
+* [PCP-652](https://tickets.puppetlabs.com/browse/PCP-652) Switch to using PCP
+v2. Drops support for message expiration.
+
 ## 0.4.0
 
 This is a feature release to enable compatibility with pcp-broker 1.0. It

--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@ Releases of this project are distributed via clojars, to use it:
 ;; connecting with handlers
 (def conn (client/connect
            {:server "wss://localhost:8142/pcp/"
-            :cert "test-resources/ssl/certs/0001_controller.pem"
-            :private-key "test-resources/ssl/private_keys/0001_controller.pem"
-            :cacert "test-resources/ssl/certs/ca.pem"}
+            :ssl-context
+            {:cert "test-resources/ssl/certs/0001_controller.pem"
+             :private-key "test-resources/ssl/private_keys/0001_controller.pem"
+             :cacert "test-resources/ssl/certs/ca.pem"}}
            {"example/cnc_request" cnc-request-handler
             :default default-request-handler}))
 

--- a/test/puppetlabs/pcp/client_test.clj
+++ b/test/puppetlabs/pcp/client_test.clj
@@ -11,7 +11,6 @@
    (let [realized-future (future true)]
      (deref realized-future)                                ; make sure the future is realized
      (map->Client {:server "wss://localhost:8142/pcp/v1"
-                   :identity "pcp://the_identity/the_type"
                    :websocket-client ""
                    :websocket-connection (atom realized-future)
                    :handlers {}
@@ -49,19 +48,6 @@
              (dispatch-message client (message/make-message :message_type "foo"))))
       (is (= "default"
              (dispatch-message client (message/make-message :message_type "bar")))))))
-
-(def make-identity #'puppetlabs.pcp.client/make-identity)
-(deftest make-identity-test
-  (testing "It returns the correct identity"
-    (is (= "pcp://client01.example.com/test"
-           (make-identity "test-resources/ssl/certs/client01.example.com.pem" "test"))))
-  (testing "It returns the correct identity from a certificate chain"
-    (is (= "pcp://client01.example.com/test"
-           (make-identity "test-resources/ssl/certs/client01-chain.example.com.pem" "test"))))
-  (testing "It throws an exception when the certificate file is empty"
-    (is (thrown-with-msg? IllegalArgumentException
-                          #"test-resources/ssl/certs/client01-empty\.example\.com.pem must contain at least 1 certificate"
-                          (make-identity "test-resources/ssl/certs/client01-empty.example.com.pem" "test")))))
 
 (def make-connection #'puppetlabs.pcp.client/make-connection)
 (deftest make-connection-test


### PR DESCRIPTION
- Manage heartbeat thread automatically
- Remove identity
- Allow passing SSLContext instead of cert names