### PR TITLE
(PCP-712) Add a on-close callback, called when the client disconnects

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,15 @@ Releases of this project are distributed via clojars, to use it:
   [conn request]
   (log/info "Default handler got message" request))
 
-;; connecting with handlers
+;; connecting with handlers; allows an optional callback that's called when the
+;; connection closes that passes the Client object as an argument
 (def conn (client/connect
            {:server "wss://localhost:8142/pcp/"
             :ssl-context
             {:cert "test-resources/ssl/certs/0001_controller.pem"
              :private-key "test-resources/ssl/private_keys/0001_controller.pem"
-             :cacert "test-resources/ssl/certs/ca.pem"}}
+             :cacert "test-resources/ssl/certs/ca.pem"}
+            :on-close-cb (fn [client] (println client))}
            {"example/cnc_request" cnc-request-handler
             :default default-request-handler}))
 

--- a/src/puppetlabs/pcp/client.clj
+++ b/src/puppetlabs/pcp/client.clj
@@ -116,7 +116,7 @@
   or ConnectException a further connection attempt will be made by following an
   exponential backoff, whereas other exceptions will be propagated."
   [client :- Client]
-  (let [{:keys [server websocket-client should-stop]} client
+  (let [{:keys [server websocket-client should-stop on-close-cb]} client
         initial-sleep 200
         sleep-multiplier 2
         maximum-sleep (* 15 1000)]
@@ -137,6 +137,7 @@
                                     ;; Format error code as a string rather than a localized number, i.e. 1,234.
                                     (log/debug (i18n/trs "WebSocket closed {0} {1}" (str code) message))
                                     (deliver stop-heartbeat true)
+                                    (when on-close-cb (on-close-cb client))
                                     (let [{:keys [should-stop websocket-connection]} client]
                                       ;; Ensure disconnect state is immediately registered as connecting.
                                       (log/debug (i18n/trs "Sleeping for up to {0} ms to retry" retry-sleep))
@@ -219,6 +220,7 @@
   "schema for connection parameters"
   {:server s/Str
    :ssl-context (s/either SslFiles SSLContext)
+   (s/optional-key :on-close-cb) Object
    (s/optional-key :type) s/Str
    (s/optional-key :user-data) s/Any
    (s/optional-key :max-message-size) s/Int})
@@ -272,6 +274,7 @@
                              :websocket-client (make-websocket-client ssl-context-factory
                                                                       (:max-message-size params))
                              :websocket-connection (atom (future true))
+                             :on-close-cb (:on-close-cb params)
                              :handlers handlers
                              :should-stop (promise)
                              :user-data user-data})

--- a/test/puppetlabs/pcp/messaging_test.clj
+++ b/test/puppetlabs/pcp/messaging_test.clj
@@ -63,15 +63,19 @@
 
 (defn connect-client-config
   "connect a client with a handler function"
-  [config handler-function]
-  (client/connect config
-   {"example/any_schema"  handler-function
-    :default              default-request-handler}))
+  ([config handler-function]
+   (connect-client-config config handler-function nil))
+  ([config handler-function on-close-cb]
+   (client/connect (assoc config :on-close-cb on-close-cb)
+    {"example/any_schema"  handler-function
+     :default              default-request-handler})))
 
 (defn connect-client
   "connect a client with a handler function, uses default configuration strategy"
-  [cn handler-fn]
-  (connect-client-config (client-config cn) handler-fn))
+  ([cn handler-fn]
+   (connect-client cn handler-fn nil))
+  ([cn handler-fn on-close-cb]
+   (connect-client-config (client-config cn) handler-fn on-close-cb)))
 
 (defmacro eventually-logged?
   [logger-id level pred & body]
@@ -203,17 +207,20 @@
                   (client/send! client (message/make-message))))))
 
 (deftest connect-to-a-down-up-down-up-broker-test
-  (with-open [client (connect-client "client01" (constantly true))]
-    (is (not (client/connected? client)) "Should not be connected yet")
-    (with-app-with-config app broker-services broker-config
-      (is (= client (client/wait-for-connection client (* 40 1000))))
-      (is (client/connected? client) "Should now be connected"))
-    ;; Allow time for the websocket connection to close, but not enough to attempt reconnecting
-    (Thread/sleep 500)
-    (is (not (client/connected? client)) "Should be disconnected")
-    (with-app-with-config app broker-services broker-config
-      (is (= client (client/wait-for-connection client (* 40 1000))))
-      (is (client/connected? client) "Should be reconnected"))))
+  (let [closed (promise)
+        on-close-cb (fn [c] (deliver closed c))]
+    (with-open [client (connect-client "client01" (constantly true) on-close-cb)]
+      (is (not (client/connected? client)) "Should not be connected yet")
+      (with-app-with-config app broker-services broker-config
+        (is (= client (client/wait-for-connection client (* 40 1000))))
+        (is (client/connected? client) "Should now be connected"))
+      ;; Allow time for the websocket connection to close, but not enough to attempt reconnecting
+      (is (= (deref closed 1000 nil) client))
+      (Thread/sleep 100)
+      (is (not (client/connected? client)) "Should be disconnected")
+      (with-app-with-config app broker-services broker-config
+        (is (= client (client/wait-for-connection client (* 40 1000))))
+        (is (client/connected? client) "Should be reconnected")))))
 
 (deftest connect-with-too-small-message-size
   (with-app-with-config app broker-services broker-config


### PR DESCRIPTION
Adds a new on-close callback option to pass in a callback that's called
when the websocket connection closes. Sync all operation is async, this
allows action to be taken whenever the connection is lost.