### PR TITLE
(PCP-713) Add an on-close callback, called when the client disconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.1.0
+
+This is a minor maintenance and feature release.
+
+* [PCP-713](https://tickets.puppetlabs.com/browse/PCP-713) Add an on-close
+callback that's called whenever the client disconnects.
+* Update to clj-parent 0.4.1 and pcp-common 1.1.1.
+
 ## 1.0.0
 
 This is a major feature release to support PCP v2. It drops support for PCP v1.

--- a/README.md
+++ b/README.md
@@ -33,13 +33,15 @@ Releases of this project are distributed via clojars, to use it:
   [conn request]
   (log/info "Default handler got message" request))
 
-;; connecting with handlers
+;; connecting with handlers; allows an optional callback that's called when the
+;; connection closes that passes the Client object as an argument
 (def conn (client/connect
            {:server "wss://localhost:8142/pcp/"
             :ssl-context
             {:cert "test-resources/ssl/certs/0001_controller.pem"
              :private-key "test-resources/ssl/private_keys/0001_controller.pem"
-             :cacert "test-resources/ssl/certs/ca.pem"}}
+             :cacert "test-resources/ssl/certs/ca.pem"}
+            :on-close-cb (fn [client] (println client))}
            {"example/cnc_request" cnc-request-handler
             :default default-request-handler}))
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject puppetlabs/pcp-client "1.0.1-SNAPSHOT"
+(defproject puppetlabs/pcp-client "1.1.0-SNAPSHOT"
   :description "client library for PCP"
   :url "https://github.com/puppetlabs/clj-pcp-client"
   :license {:name "Apache License, Version 2.0"


### PR DESCRIPTION
Adds a new on-close callback option to pass in a callback that's called
when the websocket connection closes. Sync all operation is async, this
allows action to be taken whenever the connection is lost.