### PR TITLE
(maint) Prep 1.2.0 with support for Java 9, Clojure 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: clojure
 sudo: false
-lein: 2.7.1
+lein: 2.8.1
 jdk:
+  - oraclejdk9
   - oraclejdk8
 script:
   - lein test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.0
+
+This is a feature release.
+
+* Add support for Java 9.
+
 ## 1.1.6
 
 This is a maintenance release.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject puppetlabs/pcp-client "1.1.7-SNAPSHOT"
+(defproject puppetlabs/pcp-client "1.2.0-SNAPSHOT"
   :description "client library for PCP"
   :url "https://github.com/puppetlabs/clj-pcp-client"
   :license {:name "Apache License, Version 2.0"
@@ -8,12 +8,12 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "1.0.0"]
+  :parent-project {:coords [puppetlabs/clj-parent "2.0.0"]
                    :inherit [:managed-dependencies]}
 
-  :dependencies [[puppetlabs/pcp-common "1.1.4"]
+  :dependencies [[puppetlabs/pcp-common "1.2.0"]
 
-                 [stylefruits/gniazdo "0.4.0" :exclusions [org.eclipse.jetty.websocket/websocket-client]]
+                 [stylefruits/gniazdo "1.0.1" :exclusions [org.eclipse.jetty.websocket/websocket-client]]
                  ;; We only care about org.eclipse.jetty.websocket/websocket-client
                  [puppetlabs/trapperkeeper-webserver-jetty9]
 
@@ -28,7 +28,7 @@
                  [puppetlabs/i18n]]
 
   :plugins [[lein-release "1.0.5" :exclusions [org.clojure/clojure]]
-            [lein-parent "0.3.1"]
+            [lein-parent "0.3.4"]
             [puppetlabs/i18n "0.8.0"]]
 
   :lein-release {:scm :git
@@ -42,12 +42,13 @@
   :test-paths ["test" "test-resources"]
 
   :profiles {:dev {:source-paths ["dev"]
-                   :dependencies [[puppetlabs/pcp-broker "1.3.2"]
+                   :dependencies [[puppetlabs/pcp-broker "1.4.4"]
+                                  [org.clojure/tools.nrepl]
                                   [puppetlabs/trapperkeeper]
                                   [puppetlabs/trapperkeeper :classifier "test" :scope "test"]
                                   [puppetlabs/kitchensink :classifier "test" :scope "test"]]}
-             :cljfmt {:plugins [[lein-cljfmt "0.3.0"]
-                                [lein-parent "0.2.1"]]
+             :cljfmt {:plugins [[lein-cljfmt "0.5.7" :exclusions [org.clojure/clojure]]
+                                [lein-parent "0.3.4"]]
                       :parent-project {:path "../pl-clojure-style/project.clj"
                                        :inherit [:cljfmt]}}
              :test-base [:dev

--- a/test/puppetlabs/pcp/messaging_test.clj
+++ b/test/puppetlabs/pcp/messaging_test.clj
@@ -29,7 +29,7 @@
                             :allow-unauthenticated true
                             :sort-order 1}]}
 
-   :webserver {:ssl-host     "127.0.0.1"
+   :webserver {:ssl-host     "localhost"
                ;; Default port is 8142.  Use 8143 here so we don't clash.
                :ssl-port     8143
                :client-auth  "want"


### PR DESCRIPTION
Depends on https://github.com/puppetlabs/clj-pcp-common/pull/41.