### PR TITLE
(PE-34653) update clj-parent to 5.2.9 remove stylefruits pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.4.0
+
+This is a maintenance release.
+* update clj-parent to 5.2.9 which contains multiple updates from the previous version
+* use the version for stylefruits/gniazdo from clj-parent
+
 ## 1.3.4
 
 This is a maintenance release.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject puppetlabs/pcp-client "1.3.5-SNAPSHOT"
+(defproject puppetlabs/pcp-client "1.4.0-SNAPSHOT"
   :description "client library for PCP"
   :url "https://github.com/puppetlabs/clj-pcp-client"
   :license {:name "Apache License, Version 2.0"
@@ -8,12 +8,12 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "4.9.1"]
+  :parent-project {:coords [puppetlabs/clj-parent "5.2.9"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[puppetlabs/pcp-common "1.3.5" :exclusions [org.tukaani/xz]]
 
-                 [stylefruits/gniazdo "1.2.0" :exclusions [org.eclipse.jetty.websocket/websocket-client]]
+                 [stylefruits/gniazdo nil :exclusions [org.eclipse.jetty.websocket/websocket-client]]
                  ;; We only care about org.eclipse.jetty.websocket/websocket-client
                  [puppetlabs/trapperkeeper-webserver-jetty9]
 


### PR DESCRIPTION
This updates the clj-parent version to 5.2.9, which contains a version declaration for stylefruits/gniazdo, allowing the version in this repository to not pin a specific version.

The release series was bumped up to 1.4.x due to the changes in clj-parent.

The CHANGELOG was also updated in anticipation of a release.