### PR TITLE
(maint) add certs to Client record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.1
+* add missing certs entry to Client record
+
 ## 2.0.0
 
 This a major breaking release.

--- a/src/puppetlabs/pcp/client.clj
+++ b/src/puppetlabs/pcp/client.clj
@@ -67,7 +67,8 @@
    retry?
    should-stop ;; promise that when delivered means should stop
    websocket-connection ;; atom of a promise that will be a connection or true
-   websocket-client]
+   websocket-client
+   certs]
   {(s/optional-key :user-data) s/Any} ;; a field for user data
   ClientInterface
   (connecting? [client] (-connecting? client))
@@ -330,7 +331,7 @@
    The certificate file specified can provide either a single certificate,
    or a certificate chain (with the first entry being the client's certificate)."
   [params :- ConnectParams handlers :- Handlers]
-   (let [{:keys [ssl-context cert type server user-data retry?] :or {retry? true}} params
+   (let [{:keys [ssl-context type server user-data retry?] :or {retry? true}} params
          defaulted-type (or type "agent")
          ssl-context-factory (make-ssl-context params)
          certs (when (:cert ssl-context)

--- a/test/puppetlabs/pcp/client_test.clj
+++ b/test/puppetlabs/pcp/client_test.clj
@@ -2,7 +2,10 @@
   (:require [clojure.test :refer :all]
             [puppetlabs.pcp.client :refer :all :as client]
             [puppetlabs.pcp.message-v2 :as message]
+            [schema.test :as st]
             [slingshot.test]))
+
+(use-fixtures :once st/validate-schemas)
 
 (defn make-test-client
   "A dummied up client object"
@@ -46,11 +49,6 @@
              (dispatch-message client (message/make-message :message_type "foo"))))
       (is (= "default"
              (dispatch-message client (message/make-message :message_type "bar")))))))
-
-(deftest make-connection-test
-  (with-redefs [create-websocket-session (constantly "awesome")]
-    (is (= "awesome"
-           (-make-connection (make-test-client))))))
 
 (deftest wait-for-connection-test
   (testing "when connected"

--- a/test/puppetlabs/pcp/messaging_test.clj
+++ b/test/puppetlabs/pcp/messaging_test.clj
@@ -19,6 +19,7 @@
              :refer [with-log-level with-logging-to-atom with-log-suppressed-unless-notable]]
             [slingshot.test]
             [schema.test :as st]))
+(use-fixtures :once st/validate-schemas)
 
 (def broker-config
   "A broker with ssl and own spool"


### PR DESCRIPTION
Recently the additional `certs` entry was needed in the `Client` record, but wasn't added to the record definition.  If schema validation is turned on, this causes an exception to be thrown.

This updates the record to contain the certs entry, adds the schema validation to both test namespaces, and removes an unused parameter.

A pointless test was removed as it violated the schema result of the function, and creating a valid payload would be more effort than the test is worth.